### PR TITLE
Tidy up project files

### DIFF
--- a/src/Kros.Utils.csproj
+++ b/src/Kros.Utils.csproj
@@ -1,45 +1,41 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>netstandard2.0;netcoreapp2.1;net46</TargetFrameworks>
-    <Company>KROS a.s.</Company>
-    <Title>Kros.Utils</Title>
+    <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
     <Version>1.10.1</Version>
-    <Authors>KROS a.s.</Authors>
+    <Authors>KROS a. s.</Authors>
+    <Company>KROS a. s.</Company>
     <Description>General utilities and helpers.</Description>
-    <Copyright>Copyright © KROS a.s.</Copyright>
-    <SignAssembly>false</SignAssembly>
-    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
+    <Title>Kros.Utils</Title>
+    <Copyright>Copyright © KROS a. s.</Copyright>
     <RootNamespace>Kros</RootNamespace>
-    <TargetGroup Condition="('$(TargetFramework)' == 'netcoreapp2.1') Or ('$(TargetFramework)' == 'netstandard2.0')">netcoreapp</TargetGroup>
-    <DefineConstants Condition="'$(TargetGroup)' == 'netcoreapp'">$(DefineConstants);netcoreapp</DefineConstants>
+    <DefineConstants Condition="'$(TargetFramework)' == 'netcoreapp2.1'">$(DefineConstants);netcoreapp</DefineConstants>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
   </PropertyGroup>
   <PropertyGroup>
     <PackageIcon>icon.png</PackageIcon>
-    <PackageProjectUrl>https://github.com/Kros-sk/Kros.Utils/blob/master/README.md</PackageProjectUrl>
-    <PackageTags>Kros;Utils;Utility;Helpers;Extensions; DatabaseSchema;BulkOperation;BulkUpdate;Bulk Insert;Bulk Update;</PackageTags>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <PackageProjectUrl>https://github.com/Kros-sk/Kros.Utils</PackageProjectUrl>
     <PackageReleaseNotes>https://github.com/Kros-sk/Kros.Utils/releases</PackageReleaseNotes>
+    <PackageTags>Kros;Utils;Utility;Helpers;Extensions; DatabaseSchema;BulkOperation;BulkUpdate;Bulk Insert;Bulk Update;</PackageTags>
   </PropertyGroup>
-  <ItemGroup>
-    <None Include="Resources\icon.png" Pack="true" PackagePath="" />
-  </ItemGroup>
+
   <ItemGroup>
     <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
   </ItemGroup>
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0'">
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.0" />
-    <PackageReference Include="System.Net.Http" Version="4.3.4" />
-  </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
-    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.0" />
+    <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />
     <PackageReference Include="System.Net.Http" Version="4.3.4" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'net46'">
     <Reference Include="System.Net.Http" />
   </ItemGroup>
+
   <ItemGroup>
-    <None Remove="Kros.Utils.xml" />
+    <None Include="Resources\icon.png" Pack="true" PackagePath="" />
+  </ItemGroup>
+
+  <ItemGroup>
     <None Remove="Resources\SqlIdGeneratorStoredProcedureScript.sql" />
     <None Remove="Resources\SqlIdGeneratorTableScript.sql" />
   </ItemGroup>
@@ -47,6 +43,7 @@
     <EmbeddedResource Include="Resources\SqlIdGeneratorStoredProcedureScript.sql" />
     <EmbeddedResource Include="Resources\SqlIdGeneratorTableScript.sql" />
   </ItemGroup>
+
   <ItemGroup>
     <Compile Update="Properties\Resources.Designer.cs">
       <DesignTime>True</DesignTime>

--- a/tests/Kros.Utils.UnitTests.csproj
+++ b/tests/Kros.Utils.UnitTests.csproj
@@ -1,18 +1,16 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.0</TargetFramework>
     <IsPackable>false</IsPackable>
     <AssemblyName>Kros.Utils.UnitTests</AssemblyName>
     <RootNamespace>Kros.Utils.UnitTests</RootNamespace>
-    <Company>KROS a.s.</Company>
-    <Copyright>Copyright © KROS a.s.</Copyright>
+    <Company>KROS a. s.</Company>
+    <Copyright>Copyright © KROS a. s.</Copyright>
     <SignAssembly>false</SignAssembly>
   </PropertyGroup>
   <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
     <PackageReference Include="FluentAssertions" Version="5.9.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration" Version="3.0.0" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="3.0.0" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.3.0" />
     <PackageReference Include="Nito.AsyncEx.Context" Version="5.0.0" />
     <PackageReference Include="NSubstitute" Version="4.2.1" />
     <PackageReference Include="xunit" Version="2.4.1" />
@@ -32,4 +30,7 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </None>
   </ItemGroup>
+  <Target Name="PostBuild" AfterTargets="PostBuildEvent">
+    <Exec Command="if exist &quot;$(ProjectDir)appsettings.local.json&quot; (&#xD;&#xA;  copy &quot;$(ProjectDir)appsettings.local.json&quot; &quot;$(TargetDir)&quot;&#xD;&#xA;)" />
+  </Target>
 </Project>


### PR DESCRIPTION
- Removed `netstandard2.0` framework. It is not needed, when we explicitly target .NET Core (2.1) and full framework (4.6).
- Tidy up project files.
- Updated package `Microsoft.Net.Http.Headers` for .NET Core framework.
- Test project targets .NET Core 3.
- Added post-build action in test project to copy `appsettings.local.json` (if it exists) to build directory.