### PR TITLE
Sql client

### DIFF
--- a/src/Data/BulkActions/BulkActionFactories.cs
+++ b/src/Data/BulkActions/BulkActionFactories.cs
@@ -66,7 +66,7 @@ namespace Kros.Data.BulkActions
         /// The connection string.
         /// </param>
         /// <param name="adoClientName">
-        /// Name of the ado client. (e.g. <see cref="System.Data.SqlClient.SqlConnection"/> it's: System.Data.SqlClient)
+        /// Name of the ADO client. (e.g. <see cref="Microsoft.Data.SqlClient.SqlConnection"/> it's: Microsoft.Data.SqlClient)
         /// </param>
         /// <returns>
         /// The <see cref="IBulkActionFactory"/> instance.

--- a/src/Data/BulkActions/SqlServer/SqlServerBulkActionFactory.cs
+++ b/src/Data/BulkActions/SqlServer/SqlServerBulkActionFactory.cs
@@ -1,7 +1,7 @@
 using Kros.Data.SqlServer;
 using Kros.Utils;
 using System.Data.Common;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Kros.Data.BulkActions.SqlServer
 {

--- a/src/Data/BulkActions/SqlServer/SqlServerBulkInsert.cs
+++ b/src/Data/BulkActions/SqlServer/SqlServerBulkInsert.cs
@@ -1,9 +1,9 @@
 ﻿using Kros.Data.Schema;
 using Kros.Properties;
 using Kros.Utils;
+using Microsoft.Data.SqlClient;
 using System;
 using System.Data;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 
 namespace Kros.Data.BulkActions.SqlServer

--- a/src/Data/BulkActions/SqlServer/SqlServerBulkUpdate.cs
+++ b/src/Data/BulkActions/SqlServer/SqlServerBulkUpdate.cs
@@ -1,8 +1,8 @@
 ﻿using Kros.Utils;
+using Microsoft.Data.SqlClient;
 using System;
 using System.Data;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Linq;
 using System.Threading.Tasks;
 

--- a/src/Data/DataExtensions.cs
+++ b/src/Data/DataExtensions.cs
@@ -1,7 +1,7 @@
-﻿using System;
-using System.Data;
 ﻿using Kros.Data.SqlServer;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
+using System;
+using System.Data;
 using System.Linq;
 
 namespace Kros.Data

--- a/src/Data/IdGeneratorFactories.cs
+++ b/src/Data/IdGeneratorFactories.cs
@@ -38,7 +38,7 @@ namespace Kros.Data
         /// <typeparam name="TConnection">Database connection type.</typeparam>
         /// <param name="adoClientName">
         /// Name of the database client. It identifies specific database. For example client name for
-        /// <see cref="SqlServer.SqlServerIdGeneratorFactory"/> is "System.Data.SqlClient"
+        /// <see cref="SqlServer.SqlServerIdGeneratorFactory"/> is "Microsoft.Data.SqlClient"
         /// (<see cref="SqlServer.SqlServerDataHelper.ClientId"/>).
         /// </param>
         /// <param name="factoryByConnection">

--- a/src/Data/Schema/SqlServer/SqlServerCacheKeyGenerator.cs
+++ b/src/Data/Schema/SqlServer/SqlServerCacheKeyGenerator.cs
@@ -1,6 +1,6 @@
 ﻿using Kros.Utils;
+using Microsoft.Data.SqlClient;
 using System;
-using System.Data.SqlClient;
 
 namespace Kros.Data.Schema.SqlServer
 {

--- a/src/Data/Schema/SqlServer/SqlServerColumnSchema.cs
+++ b/src/Data/Schema/SqlServer/SqlServerColumnSchema.cs
@@ -1,7 +1,6 @@
 ﻿using Kros.Utils;
-using System.Collections.Generic;
+using Microsoft.Data.SqlClient;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace Kros.Data.Schema.SqlServer
 {

--- a/src/Data/Schema/SqlServer/SqlServerSchemaLoader.cs
+++ b/src/Data/Schema/SqlServer/SqlServerSchemaLoader.cs
@@ -1,9 +1,9 @@
 ﻿using Kros.Properties;
 using Kros.Utils;
+using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 
 namespace Kros.Data.Schema.SqlServer
 {

--- a/src/Data/SqlServer/SqlConnectionExtensions.cs
+++ b/src/Data/SqlServer/SqlConnectionExtensions.cs
@@ -1,6 +1,6 @@
 ﻿using Kros.Utils;
+using Microsoft.Data.SqlClient;
 using System;
-using System.Data.SqlClient;
 
 namespace Kros.Data.SqlServer
 {

--- a/src/Data/SqlServer/SqlServerDataHelper.cs
+++ b/src/Data/SqlServer/SqlServerDataHelper.cs
@@ -9,6 +9,6 @@
         /// Identification of Microsoft SQL Server classes (used for example in <see cref="SqlServerIdGeneratorFactory"/>,
         /// <see cref="BulkActions.SqlServer.SqlServerBulkActionFactory"/>).
         /// </summary>
-        public const string ClientId = "System.Data.SqlClient";
+        public const string ClientId = "Microsoft.Data.SqlClient";
     }
 }

--- a/src/Data/SqlServer/SqlServerErrorCode.cs
+++ b/src/Data/SqlServer/SqlServerErrorCode.cs
@@ -3,8 +3,8 @@
     /// <summary>
     /// Some of the error codes for Microsoft SQL Server.
     /// </summary>
-    /// <remarks>Error code is in exception <see cref="System.Data.SqlClient.SqlException"/>,
-    /// in the <see cref="System.Data.SqlClient.SqlException.Number"/> property. List of all error codes is at
+    /// <remarks>Error code is in exception <see cref="Microsoft.Data.SqlClient.SqlException"/>,
+    /// in the <see cref="Microsoft.Data.SqlClient.SqlException.Number"/> property. List of all error codes is at
     /// <see href="https://msdn.microsoft.com/en-us/library/cc645603.aspx"/>.</remarks>
     public enum SqlServerErrorCode
     {

--- a/src/Data/SqlServer/SqlServerIdGenerator.cs
+++ b/src/Data/SqlServer/SqlServerIdGenerator.cs
@@ -1,7 +1,7 @@
 ﻿using Kros.Utils;
+using Microsoft.Data.SqlClient;
 using System;
 using System.Data.Common;
-using System.Data.SqlClient;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Kros.Data.SqlServer

--- a/src/Data/SqlServer/SqlServerIdGeneratorFactory.cs
+++ b/src/Data/SqlServer/SqlServerIdGeneratorFactory.cs
@@ -1,5 +1,5 @@
 ﻿using Kros.Utils;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 
 namespace Kros.Data.SqlServer
 {

--- a/src/Kros.Utils.csproj
+++ b/src/Kros.Utils.csproj
@@ -21,7 +21,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="System.Data.SqlClient" Version="4.7.0" />
+    <PackageReference Include="Microsoft.Data.SqlClient" Version="1.1.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'">
     <PackageReference Include="Microsoft.Net.Http.Headers" Version="2.2.8" />

--- a/src/Kros.Utils.csproj
+++ b/src/Kros.Utils.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <TargetFrameworks>netcoreapp2.1;net46</TargetFrameworks>
-    <Version>1.10.1</Version>
+    <Version>1.11.0-alpha.1</Version>
     <Authors>KROS a. s.</Authors>
     <Company>KROS a. s.</Company>
     <Description>General utilities and helpers.</Description>

--- a/src/UnitTests/SqlServerTestHelper.cs
+++ b/src/UnitTests/SqlServerTestHelper.cs
@@ -1,8 +1,8 @@
 ﻿using Kros.Data;
 using Kros.Utils;
+using Microsoft.Data.SqlClient;
 using System;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Diagnostics.CodeAnalysis;
 
 namespace Kros.UnitTests

--- a/tests/Data/BulkActions/BulkActionFactoriesShould.cs
+++ b/tests/Data/BulkActions/BulkActionFactoriesShould.cs
@@ -1,8 +1,8 @@
 ﻿using FluentAssertions;
 using Kros.Data.BulkActions;
 using Kros.Data.SqlServer;
+using Microsoft.Data.SqlClient;
 using System;
-using System.Data.SqlClient;
 using Xunit;
 
 namespace Kros.Utils.UnitTests.Data

--- a/tests/Data/BulkActions/SqlServerBulkActionFactoryShould.cs
+++ b/tests/Data/BulkActions/SqlServerBulkActionFactoryShould.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using Kros.Data.BulkActions.SqlServer;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace Kros.Utils.UnitTests.Data.BulkActions

--- a/tests/Data/BulkActions/SqlServerBulkInsertShould.cs
+++ b/tests/Data/BulkActions/SqlServerBulkInsertShould.cs
@@ -1,11 +1,11 @@
 ﻿using FluentAssertions;
 using Kros.Data.BulkActions;
 using Kros.Data.BulkActions.SqlServer;
+using Microsoft.Data.SqlClient;
 using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Threading.Tasks;
 using Xunit;
 

--- a/tests/Data/BulkActions/SqlServerBulkUpdateShould.cs
+++ b/tests/Data/BulkActions/SqlServerBulkUpdateShould.cs
@@ -2,11 +2,11 @@
 using Kros.Data.BulkActions;
 using Kros.Data.BulkActions.SqlServer;
 using Kros.UnitTests;
+using Microsoft.Data.SqlClient;
 using Nito.AsyncEx;
 using System;
 using System.Collections.Generic;
 using System.Data;
-using System.Data.SqlClient;
 using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;

--- a/tests/Data/IdGenerator/IdGeneratorFactoriesShould.cs
+++ b/tests/Data/IdGenerator/IdGeneratorFactoriesShould.cs
@@ -1,8 +1,8 @@
 ﻿using FluentAssertions;
 using Kros.Data;
 using Kros.Data.SqlServer;
+using Microsoft.Data.SqlClient;
 using System;
-using System.Data.SqlClient;
 using Xunit;
 
 namespace Kros.Utils.UnitTests.Data

--- a/tests/Data/IdGenerator/SqlServerIdGeneratorFactoryShould.cs
+++ b/tests/Data/IdGenerator/SqlServerIdGeneratorFactoryShould.cs
@@ -1,6 +1,6 @@
 ﻿using FluentAssertions;
 using Kros.Data.SqlServer;
-using System.Data.SqlClient;
+using Microsoft.Data.SqlClient;
 using Xunit;
 
 namespace Kros.Utils.UnitTests.Data

--- a/tests/Data/IdGenerator/SqlServerIdGeneratorShould.cs
+++ b/tests/Data/IdGenerator/SqlServerIdGeneratorShould.cs
@@ -2,8 +2,8 @@
 using Kros.Data;
 using Kros.Data.SqlServer;
 using Kros.UnitTests;
+using Microsoft.Data.SqlClient;
 using System.Collections.Generic;
-using System.Data.SqlClient;
 using System.Diagnostics.CodeAnalysis;
 using Xunit;
 


### PR DESCRIPTION
**Replace `System.Data.SqlClient` with `Microsoft.Data.SqlClient`.**

`System.Data.SqlClient` works and will be bug-fixed and security-fixed in the future. But it will not be updated with new SQL Server's features. New package `Microsoft.Data.SqlClient` is the package which will be used in the future.

More info: https://devblogs.microsoft.com/dotnet/introducing-the-new-microsoftdatasqlclient/

[There is some problem with the latest `System.Data.SqlClient` package in Azure Functions.](https://github.com/Azure/azure-functions-host/issues/3903) It does not work - the last working version in Azure Functions is 4.5.x.