### PR TITLE
Add as task extensions

### DIFF
--- a/src/Extensions/AsTaskExtensions.cs
+++ b/src/Extensions/AsTaskExtensions.cs
@@ -1,0 +1,27 @@
+﻿using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace Kros.Extensions
+{
+    /// <summary>
+    /// Extension for easier creating task from value.
+    /// </summary>
+    public static class AsTaskExtensions
+    {
+        /// <summary>
+        /// Create <see cref="Task{T}"/> of <see cref="IEnumerable{T}"/> from items.
+        /// </summary>
+        /// <typeparam name="T">Type of items.</typeparam>
+        /// <param name="items">The items.</param>
+        public static Task<IEnumerable<T>> AsTask<T>(this IEnumerable<T> items)
+            => Task.FromResult(items);
+
+        /// <summary>
+        /// Create <see cref="Task{T}"/> from value.
+        /// </summary>
+        /// <typeparam name="T">Type of value.</typeparam>
+        /// <param name="value">The value.</param>
+        public static Task<T> AsTaskSingleValue<T>(this T value)
+            => Task.FromResult(value);
+    }
+}

--- a/tests/Extensions/AsTaskExtensionsShould.cs
+++ b/tests/Extensions/AsTaskExtensionsShould.cs
@@ -1,0 +1,34 @@
+﻿using FluentAssertions;
+using Kros.Extensions;
+using System.Collections.Generic;
+using Xunit;
+
+namespace Kros.Utils.UnitTests.Extensions
+{
+    public class AsTaskExtensionsShould
+    {
+        [Fact]
+        public async void CreateTaskFromIEnumerable()
+        {
+            IEnumerable<int> data = new List<int>() { 1, 2, 5, 6 };
+
+            IEnumerable<int> actual = await data.AsTask();
+
+            actual.Should().BeEquivalentTo(data);
+        }
+
+        [Fact]
+        public async void CreateTaskFromSingleValue()
+        {
+            var foo = new
+            {
+                Name = "foo",
+                LastName = "bar"
+            };
+
+            var actual = await foo.AsTaskSingleValue();
+
+            actual.Should().BeEquivalentTo(foo);
+        }
+    }
+}


### PR DESCRIPTION
This PR add extensions for esier creating `Task` from values to comply with the required api.

In many places we have construction like:
```CSharp
public Task<IEnumerable<Model>> Handle(params)
 => Task.FromResult(_database.Query<Model>().Select(columns...).Where(condition...).AsEnumerable());
```
It's hard to read.

With this extensions  it might look like this:
```CSharp
public Task<IEnumerable<Model>> Handle(params)
 => _database.Query<Model>().Select(columns...).Where(condition...).AsTask();
```
Isn't it better?